### PR TITLE
Fix: Attempt to resolve YouTube video popup issues

### DIFF
--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -377,7 +377,6 @@ function orido_tm_popup(){
 	});
 	jQuery('.popup-youtube, .popup-vimeo').each(function() { // the containers for all your galleries
 		jQuery(this).magnificPopup({
-			disableOn: 700,
 			type: 'iframe',
 			mainClass: 'mfp-fade',
 			removalDelay: 160,

--- a/index.html
+++ b/index.html
@@ -41,6 +41,10 @@
 </head>
 
 <body>
+<div style="padding: 20px; background-color: #f0f0f0; text-align: center; border: 1px solid #ccc;">
+    <p>Simplified Test Case:</p>
+    <a class="popup-youtube" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Test Video Link (Simple)</a>
+</div>
 
 	<!-- PRELOADER -->
 	<div id="preloader">
@@ -568,7 +572,7 @@
 										<h3 class="title text-[32px] tracking-[-1px] font-medium"><span
 												class="inline-block relative">Product for TV channel</span></h3>
 									</div>
-									<a class="orido_tm_full_link absolute inset-0 z-[5] popup-vimeo"
+									<a class="orido_tm_full_link absolute inset-0 z-[5] popup-youtube"
 										href="https://www.youtube.com/watch?v=UqgOyzLzVbE&feature=youtu.be&ab_channel=TechnoVistaLimited"></a>
 								</div>
 							</li>


### PR DESCRIPTION
This commit includes several changes aimed at fixing issues with YouTube video links not playing in Magnific Popup:

1.  Modified `assets/js/init.js` to remove the `disableOn: 700` option from the Magnific Popup initialization for `.popup-youtube` and `.popup-vimeo` elements. This ensures popups are not disabled on smaller screens, aiding in testing and potentially resolving one aspect of the problem.

2.  Added a simplified test case directly in `index.html` after the `<body>` tag. This link ("Test Video Link (Simple)") is intended to help isolate whether Magnific Popup for YouTube is functioning at a basic level, outside of more complex page structures.

3.  Corrected an HTML class in `index.html` for a portfolio item. A link to a YouTube video was incorrectly using the `popup-vimeo` class; this has been changed to `popup-youtube` for correct handling by Magnific Popup.

These changes are part of an ongoing effort to diagnose and fix the video playback problem. Further testing will be needed to confirm if these steps have fully resolved the issue.